### PR TITLE
[DE-677] DE-631 - CRUD for Subscription Components endpoints part 3

### DIFF
--- a/tests/src/test/java/com/maxio/advancedbilling/controllers/subscriptioncomponents/SubscriptionComponentsBulkResetSubscriptionComponentsPricePointsTest.java
+++ b/tests/src/test/java/com/maxio/advancedbilling/controllers/subscriptioncomponents/SubscriptionComponentsBulkResetSubscriptionComponentsPricePointsTest.java
@@ -1,0 +1,138 @@
+package com.maxio.advancedbilling.controllers.subscriptioncomponents;
+
+import com.maxio.advancedbilling.TestClient;
+import com.maxio.advancedbilling.controllers.SubscriptionComponentsController;
+import com.maxio.advancedbilling.exceptions.ApiException;
+import com.maxio.advancedbilling.models.BulkComponentsPricePointAssignment;
+import com.maxio.advancedbilling.models.Component;
+import com.maxio.advancedbilling.models.ComponentPricePointAssignment;
+import com.maxio.advancedbilling.models.Customer;
+import com.maxio.advancedbilling.models.ListSubscriptionComponentsInput;
+import com.maxio.advancedbilling.models.Product;
+import com.maxio.advancedbilling.models.ProductFamily;
+import com.maxio.advancedbilling.models.Subscription;
+import com.maxio.advancedbilling.models.SubscriptionComponent;
+import com.maxio.advancedbilling.models.SubscriptionComponentResponse;
+import com.maxio.advancedbilling.models.containers.ComponentPricePointAssignmentPricePoint;
+import com.maxio.advancedbilling.utils.TestSetup;
+import com.maxio.advancedbilling.utils.TestTeardown;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.maxio.advancedbilling.utils.assertions.CommonAssertions.assertNotFound;
+import static com.maxio.advancedbilling.utils.assertions.CommonAssertions.assertUnauthorized;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubscriptionComponentsBulkResetSubscriptionComponentsPricePointsTest {
+    private static final TestSetup TEST_SETUP = new TestSetup();
+    private static final SubscriptionComponentsController SUBSCRIPTION_COMPONENTS_CONTROLLER =
+            TestClient.createClient().getSubscriptionComponentsController();
+
+    private static Product product;
+    private static Customer customer;
+    private static Subscription subscription;
+
+    private static Integer meteredComponentDefaultPricePointId;
+    private static Integer quantityBasedComponentDefaultPricePointId;
+
+    @BeforeAll
+    static void setup() throws IOException, ApiException {
+        ProductFamily productFamily = TEST_SETUP.createProductFamily();
+        product = TEST_SETUP.createProduct(productFamily);
+
+        Component meteredComponent = TEST_SETUP.createMeteredComponent(productFamily, 1.0);
+        meteredComponentDefaultPricePointId = meteredComponent.getDefaultPricePointId();
+
+        Component quantityBasedComponent = TEST_SETUP.createQuantityBasedComponent(productFamily.getId());
+        quantityBasedComponentDefaultPricePointId = quantityBasedComponent.getDefaultPricePointId();
+
+        customer = TEST_SETUP.createCustomer();
+        subscription = TEST_SETUP.createSubscription(customer, product);
+
+        SUBSCRIPTION_COMPONENTS_CONTROLLER
+                .bulkUpdateSubscriptionComponentsPricePoints(
+                        subscription.getId(),
+                        new BulkComponentsPricePointAssignment(List.of(
+                                new ComponentPricePointAssignment.Builder()
+                                        .componentId(meteredComponent.getId())
+                                        .pricePoint(ComponentPricePointAssignmentPricePoint.fromNumber(TEST_SETUP
+                                                        .createPricePointForComponent(meteredComponent.getId(), 12.5)
+                                                        .getId()
+                                                )
+                                        )
+                                        .build(),
+                                new ComponentPricePointAssignment.Builder()
+                                        .componentId(quantityBasedComponent.getId())
+                                        .pricePoint(ComponentPricePointAssignmentPricePoint.fromString(TEST_SETUP
+                                                        .createComponentPricePoint(quantityBasedComponent.getId())
+                                                        .getHandle()
+                                                )
+                                        )
+                                        .build()
+                        ))
+                );
+    }
+
+    @AfterAll
+    static void teardown() throws IOException, ApiException {
+        new TestTeardown().deleteCustomer(customer);
+    }
+
+    @Test
+    void shouldResetSubscriptionComponentsPricePoints() throws IOException, ApiException {
+        // when
+        Subscription actualSubscription = SUBSCRIPTION_COMPONENTS_CONTROLLER
+                .bulkResetSubscriptionComponentsPricePoints(subscription.getId())
+                .getSubscription();
+
+        // then
+        assertThat(actualSubscription)
+                .usingRecursiveComparison()
+                .ignoringFields(
+                        "customer.countryName",
+                        "customer.stateName",
+                        "dunningCommunicationDelayEnabled",
+                        "dunningCommunicationDelayTimeZone",
+                        "group",
+                        "prepaidDunning",
+                        "productPricePointType",
+                        "updatedAt"
+                )
+                .isEqualTo(subscription);
+
+        assertThat(actualSubscription.getCustomer().getCountryName()).isNull();
+        assertThat(actualSubscription.getCustomer().getStateName()).isNull();
+        assertThat(actualSubscription.getDunningCommunicationDelayEnabled()).isNull();
+        assertThat(actualSubscription.getDunningCommunicationDelayTimeZone()).isNull();
+        assertThat(actualSubscription.getGroup()).isNull();
+        assertThat(actualSubscription.getPrepaidDunning()).isFalse();
+        assertThat(actualSubscription.getProductPricePointType()).isNull();
+
+        // assert that the subscription components' price points are reset to defaults
+        assertThat(SUBSCRIPTION_COMPONENTS_CONTROLLER
+                .listSubscriptionComponents(new ListSubscriptionComponentsInput.Builder(subscription.getId()).build())
+        )
+                .hasSize(2)
+                .extracting(SubscriptionComponentResponse::getComponent)
+                .extracting(SubscriptionComponent::getPricePointId)
+                .containsExactlyInAnyOrder(meteredComponentDefaultPricePointId, quantityBasedComponentDefaultPricePointId);
+    }
+
+    @Test
+    void shouldReturn404ForNotExistentSubscription() {
+        // when - then
+        assertNotFound(() -> SUBSCRIPTION_COMPONENTS_CONTROLLER.bulkResetSubscriptionComponentsPricePoints(123));
+    }
+
+    @Test
+    void shouldNotBulkResetWhenProvidingInvalidCredentials() {
+        // when - then
+        assertUnauthorized(() -> TestClient.createInvalidCredentialsClient().getSubscriptionComponentsController()
+                .bulkResetSubscriptionComponentsPricePoints(subscription.getId())
+        );
+    }
+}

--- a/tests/src/test/java/com/maxio/advancedbilling/controllers/subscriptioncomponents/SubscriptionComponentsBulkUpdateSubscriptionComponentsPricePointsTest.java
+++ b/tests/src/test/java/com/maxio/advancedbilling/controllers/subscriptioncomponents/SubscriptionComponentsBulkUpdateSubscriptionComponentsPricePointsTest.java
@@ -1,0 +1,182 @@
+package com.maxio.advancedbilling.controllers.subscriptioncomponents;
+
+import com.maxio.advancedbilling.TestClient;
+import com.maxio.advancedbilling.controllers.SubscriptionComponentsController;
+import com.maxio.advancedbilling.exceptions.ApiException;
+import com.maxio.advancedbilling.exceptions.ComponentPricePointErrorException;
+import com.maxio.advancedbilling.models.BulkComponentsPricePointAssignment;
+import com.maxio.advancedbilling.models.Component;
+import com.maxio.advancedbilling.models.ComponentPricePoint;
+import com.maxio.advancedbilling.models.ComponentPricePointAssignment;
+import com.maxio.advancedbilling.models.ComponentPricePointErrorItem;
+import com.maxio.advancedbilling.models.Customer;
+import com.maxio.advancedbilling.models.ProductFamily;
+import com.maxio.advancedbilling.models.Subscription;
+import com.maxio.advancedbilling.models.containers.ComponentPricePointAssignmentPricePoint;
+import com.maxio.advancedbilling.utils.TestSetup;
+import com.maxio.advancedbilling.utils.TestTeardown;
+import com.maxio.advancedbilling.utils.assertions.CommonAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.maxio.advancedbilling.utils.assertions.CommonAssertions.assertNotFound;
+import static com.maxio.advancedbilling.utils.assertions.CommonAssertions.assertUnauthorized;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubscriptionComponentsBulkUpdateSubscriptionComponentsPricePointsTest {
+    private static final TestSetup TEST_SETUP = new TestSetup();
+    private static final SubscriptionComponentsController SUBSCRIPTION_COMPONENTS_CONTROLLER =
+            TestClient.createClient().getSubscriptionComponentsController();
+
+    private static Component meteredComponent;
+    private static Component quantityBasedComponent;
+    private static Customer customer;
+    private static Subscription subscription;
+
+    @BeforeAll
+    static void setup() throws IOException, ApiException {
+        ProductFamily productFamily = TEST_SETUP.createProductFamily();
+        meteredComponent = TEST_SETUP.createMeteredComponent(productFamily, 1.0);
+        quantityBasedComponent = TEST_SETUP.createQuantityBasedComponent(productFamily.getId());
+
+        customer = TEST_SETUP.createCustomer();
+        subscription = TEST_SETUP.createSubscription(customer, TEST_SETUP.createProduct(productFamily));
+    }
+
+    @AfterAll
+    static void teardown() throws IOException, ApiException {
+        new TestTeardown().deleteCustomer(customer);
+    }
+
+    @Test
+    void shouldBulkUpdateSubscriptionComponentsPricePoints() throws IOException, ApiException {
+        // given
+        ComponentPricePoint perUnitPricePoint = TEST_SETUP.createPricePointForComponent(meteredComponent.getId(), 12.5);
+        ComponentPricePoint volumePricePoint = TEST_SETUP.createComponentPricePoint(quantityBasedComponent.getId());
+
+        // when
+        List<ComponentPricePointAssignment> components = SUBSCRIPTION_COMPONENTS_CONTROLLER
+                .bulkUpdateSubscriptionComponentsPricePoints(
+                        subscription.getId(),
+                        new BulkComponentsPricePointAssignment(List.of(
+                                new ComponentPricePointAssignment.Builder()
+                                        .componentId(meteredComponent.getId())
+                                        .pricePoint(ComponentPricePointAssignmentPricePoint.fromNumber(perUnitPricePoint.getId()))
+                                        .build(),
+                                new ComponentPricePointAssignment.Builder()
+                                        .componentId(quantityBasedComponent.getId())
+                                        .pricePoint(ComponentPricePointAssignmentPricePoint.fromString(volumePricePoint.getHandle()))
+                                        .build()
+                        ))
+                )
+                .getComponents();
+
+        // then
+        assertThat(components)
+                .hasSize(2)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("additionalProperties")
+                .containsExactlyInAnyOrder(
+                        new ComponentPricePointAssignment.Builder()
+                                .componentId(meteredComponent.getId())
+                                .pricePoint(ComponentPricePointAssignmentPricePoint.fromNumber(perUnitPricePoint.getId()))
+                                .build(),
+                        new ComponentPricePointAssignment.Builder()
+                                .componentId(quantityBasedComponent.getId())
+                                .pricePoint(ComponentPricePointAssignmentPricePoint.fromString(volumePricePoint.getHandle()))
+                                .build()
+                );
+    }
+
+    @ParameterizedTest
+    @MethodSource("argsForShouldReturn422WhenRequestBodyIsIncorrect")
+    void shouldReturn422WhenRequestBodyIsIncorrect(BulkComponentsPricePointAssignment requestBody,
+                                                   ComponentPricePointErrorItem... expectedErrors) {
+        // when - then
+        CommonAssertions.assertUnprocessableEntity(
+                ComponentPricePointErrorException.class,
+                () -> SUBSCRIPTION_COMPONENTS_CONTROLLER
+                        .bulkUpdateSubscriptionComponentsPricePoints(subscription.getId(), requestBody),
+                e -> assertThat(e.getErrors())
+                        .usingRecursiveFieldByFieldElementComparatorIgnoringFields("additionalProperties")
+                        .containsExactlyInAnyOrder(expectedErrors)
+        );
+    }
+
+    private static Stream<Arguments> argsForShouldReturn422WhenRequestBodyIsIncorrect() throws IOException, ApiException {
+        ComponentPricePoint componentPricePoint = TEST_SETUP
+                .createPricePointForComponent(meteredComponent.getId(), 12.5);
+
+        return Stream.of(
+                Arguments.arguments(
+                        // request
+                        new BulkComponentsPricePointAssignment(List.of(
+                                new ComponentPricePointAssignment()
+                        )),
+                        // expected errors
+                        new ComponentPricePointErrorItem[]{
+                                new ComponentPricePointErrorItem.Builder()
+                                        .message("Price Point does not belong to Component")
+                                        .build()
+                        }
+                ),
+                Arguments.arguments(
+                        // request
+                        new BulkComponentsPricePointAssignment(List.of(
+                                new ComponentPricePointAssignment.Builder()
+                                        .componentId(meteredComponent.getId())
+                                        .pricePoint(ComponentPricePointAssignmentPricePoint.fromNumber(123))
+                                        .build()
+                        )),
+                        // expected errors
+                        new ComponentPricePointErrorItem[]{
+                                new ComponentPricePointErrorItem.Builder()
+                                        .componentId(meteredComponent.getId())
+                                        .pricePoint(123)
+                                        .message("Price Point does not belong to Component")
+                                        .build()
+                        }
+                ),
+                Arguments.arguments(
+                        // request
+                        new BulkComponentsPricePointAssignment(List.of(
+                                new ComponentPricePointAssignment.Builder()
+                                        .componentId(123)
+                                        .pricePoint(ComponentPricePointAssignmentPricePoint.fromNumber(componentPricePoint.getId()))
+                                        .build()
+                        )),
+                        // expected errors
+                        new ComponentPricePointErrorItem[]{
+                                new ComponentPricePointErrorItem.Builder()
+                                        .componentId(123)
+                                        .pricePoint(componentPricePoint.getId())
+                                        .message("Component does not belong to this Product Family")
+                                        .build()
+                        }
+                )
+        );
+    }
+
+    @Test
+    void shouldReturn404ForNotExistentSubscription() {
+        // when - then
+        assertNotFound(() -> SUBSCRIPTION_COMPONENTS_CONTROLLER
+                .bulkUpdateSubscriptionComponentsPricePoints(123, new BulkComponentsPricePointAssignment())
+        );
+    }
+
+    @Test
+    void shouldNotBulkUpdateWhenProvidingInvalidCredentials() {
+        // when - then
+        assertUnauthorized(() -> TestClient.createInvalidCredentialsClient().getSubscriptionComponentsController()
+                .bulkUpdateSubscriptionComponentsPricePoints(subscription.getId(), new BulkComponentsPricePointAssignment())
+        );
+    }
+}

--- a/tests/src/test/java/com/maxio/advancedbilling/controllers/subscriptioncomponents/SubscriptionComponentsDeletePrepaidUsageAllocationTest.java
+++ b/tests/src/test/java/com/maxio/advancedbilling/controllers/subscriptioncomponents/SubscriptionComponentsDeletePrepaidUsageAllocationTest.java
@@ -1,0 +1,199 @@
+package com.maxio.advancedbilling.controllers.subscriptioncomponents;
+
+import com.maxio.advancedbilling.AdvancedBillingClient;
+import com.maxio.advancedbilling.TestClient;
+import com.maxio.advancedbilling.controllers.InvoicesController;
+import com.maxio.advancedbilling.controllers.SubscriptionComponentsController;
+import com.maxio.advancedbilling.controllers.SubscriptionInvoiceAccountController;
+import com.maxio.advancedbilling.exceptions.ApiException;
+import com.maxio.advancedbilling.models.Allocation;
+import com.maxio.advancedbilling.models.Component;
+import com.maxio.advancedbilling.models.CreateAllocation;
+import com.maxio.advancedbilling.models.CreateAllocationRequest;
+import com.maxio.advancedbilling.models.CreditNote;
+import com.maxio.advancedbilling.models.CreditScheme;
+import com.maxio.advancedbilling.models.CreditSchemeRequest;
+import com.maxio.advancedbilling.models.Customer;
+import com.maxio.advancedbilling.models.InvoiceRefund;
+import com.maxio.advancedbilling.models.ListCreditNotesInput;
+import com.maxio.advancedbilling.models.ProductFamily;
+import com.maxio.advancedbilling.models.Subscription;
+import com.maxio.advancedbilling.utils.TestSetup;
+import com.maxio.advancedbilling.utils.TestTeardown;
+import org.assertj.core.api.ThrowingConsumer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.maxio.advancedbilling.utils.assertions.CommonAssertions.assertNotFound;
+import static com.maxio.advancedbilling.utils.assertions.CommonAssertions.assertUnauthorized;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubscriptionComponentsDeletePrepaidUsageAllocationTest {
+    private static final TestSetup TEST_SETUP = new TestSetup();
+    private static final AdvancedBillingClient ADVANCED_BILLING_CLIENT = TestClient.createClient();
+
+    private static final SubscriptionComponentsController SUBSCRIPTION_COMPONENTS_CONTROLLER = ADVANCED_BILLING_CLIENT
+            .getSubscriptionComponentsController();
+    private static final SubscriptionInvoiceAccountController SUBSCRIPTION_INVOICE_ACCOUNT_CONTROLLER = ADVANCED_BILLING_CLIENT
+            .getSubscriptionInvoiceAccountController();
+    private static final InvoicesController INVOICES_CONTROLLER = ADVANCED_BILLING_CLIENT
+            .getInvoicesController();
+
+    private static ProductFamily productFamily;
+    private static Component prepaidComponent;
+    private static Allocation allocation;
+    private static Customer customer;
+    private static Subscription subscription;
+
+    @BeforeAll
+    static void setup() throws IOException, ApiException {
+        productFamily = TEST_SETUP.createProductFamily();
+        customer = TEST_SETUP.createCustomer();
+        prepaidComponent = TEST_SETUP.createPrepaidComponent(productFamily, 2.0);
+        subscription = TEST_SETUP.createSubscription(customer, TEST_SETUP.createProduct(productFamily));
+        allocation = allocateComponent(subscription.getId(), prepaidComponent.getId());
+    }
+
+    @AfterAll
+    static void teardown() throws IOException, ApiException {
+        new TestTeardown().deleteCustomer(customer);
+    }
+
+    @ParameterizedTest
+    @MethodSource("argsForShouldDeletePrepaidUsageAllocationWithDifferentCreditSchemas")
+    void shouldDeletePrepaidUsageAllocationWithDifferentCreditSchemas(CreditScheme creditScheme,
+                                                                      ThrowingConsumer<Integer> assertionsConsumer) throws Exception {
+        // given
+        Integer subscriptionId = TEST_SETUP.createSubscription(customer, TEST_SETUP.createProduct(productFamily)).getId();
+        Component prepaidComponent = TEST_SETUP.createPrepaidComponent(productFamily, 2.0);
+        Allocation allocation = allocateComponent(subscriptionId, prepaidComponent.getId());
+
+        // when
+        SUBSCRIPTION_COMPONENTS_CONTROLLER.deletePrepaidUsageAllocation(
+                subscriptionId,
+                prepaidComponent.getId(),
+                allocation.getAllocationId(),
+                new CreditSchemeRequest(creditScheme)
+        );
+
+        // then
+        assertionsConsumer.accept(subscriptionId);
+    }
+
+    private static Stream<Arguments> argsForShouldDeletePrepaidUsageAllocationWithDifferentCreditSchemas() {
+        return Stream.of(
+                Arguments.arguments(
+                        CreditScheme.NONE,
+                        (ThrowingConsumer<Integer>) subscriptionId -> {
+                            assertListAllocationsIsEmpty(subscriptionId);
+                            assertThat(getServiceCreditsBalanceInCents(subscriptionId)).isEqualTo(0L);
+                            assertThat(getCreditNotesWithRefunds(subscriptionId)).isEmpty();
+                        }
+                ),
+                Arguments.arguments(
+                        CreditScheme.CREDIT,
+                        (ThrowingConsumer<Integer>) subscriptionId -> {
+                            assertListAllocationsIsEmpty(subscriptionId);
+                            assertThat(getServiceCreditsBalanceInCents(subscriptionId)).isEqualTo(2000L);
+                            assertThat(getCreditNotesWithRefunds(subscriptionId)).isEmpty();
+                        }
+                ),
+                Arguments.arguments(
+                        CreditScheme.REFUND,
+                        (ThrowingConsumer<Integer>) subscriptionId -> {
+                            assertListAllocationsIsEmpty(subscriptionId);
+                            assertThat(getServiceCreditsBalanceInCents(subscriptionId)).isEqualTo(0L);
+
+                            List<CreditNote> creditNotesWithRefunds = getCreditNotesWithRefunds(subscriptionId);
+                            assertThat(creditNotesWithRefunds).hasSize(1);
+
+                            List<InvoiceRefund> refunds = creditNotesWithRefunds.get(0).getRefunds();
+                            assertThat(refunds)
+                                    .hasSize(1)
+                                    .singleElement()
+                                    .satisfies(invoiceRefund -> {
+                                        assertThat(invoiceRefund.getMemo()).isEqualTo("Refund for reverted prepaid usage allocation: 10 units");
+                                        assertThat(invoiceRefund.getOriginalAmount()).isEqualTo("20.0");
+                                        assertThat(invoiceRefund.getAppliedAmount()).isEqualTo("20.0");
+                                    });
+                        }
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("argsForShouldReturn404ForNotExistentResources")
+    void shouldReturn404ForNotExistentResources(int subscriptionId, int componentId, int allocationId) {
+        // when - then
+        assertNotFound(() -> SUBSCRIPTION_COMPONENTS_CONTROLLER.deletePrepaidUsageAllocation(
+                subscriptionId,
+                componentId,
+                allocationId,
+                new CreditSchemeRequest(CreditScheme.NONE)
+        ));
+    }
+
+    private static Stream<Arguments> argsForShouldReturn404ForNotExistentResources() {
+        return Stream.of(
+                Arguments.arguments(subscription.getId(), prepaidComponent.getId(), 123),
+                Arguments.arguments(subscription.getId(), 123, allocation.getAllocationId()),
+                Arguments.arguments(123, prepaidComponent.getId(), allocation.getAllocationId()),
+                Arguments.arguments(111, 222, 333)
+        );
+    }
+
+    @Test
+    void shouldNotBulkResetWhenProvidingInvalidCredentials() {
+        // when - then
+        assertUnauthorized(() -> TestClient.createInvalidCredentialsClient().getSubscriptionComponentsController()
+                .deletePrepaidUsageAllocation(
+                        subscription.getId(),
+                        prepaidComponent.getId(),
+                        allocation.getAllocationId(),
+                        new CreditSchemeRequest(CreditScheme.NONE)
+                )
+        );
+    }
+
+    private static Allocation allocateComponent(int subscriptionId, int componentId) throws ApiException, IOException {
+        return SUBSCRIPTION_COMPONENTS_CONTROLLER.allocateComponent(
+                subscriptionId,
+                componentId,
+                new CreateAllocationRequest(new CreateAllocation.Builder()
+                        .quantity(10.0)
+                        .memo("Recoding component allocation")
+                        .build()
+                )
+        ).getAllocation();
+    }
+
+    private static void assertListAllocationsIsEmpty(int subscriptionId) throws IOException, ApiException {
+        assertThat(SUBSCRIPTION_COMPONENTS_CONTROLLER
+                .listAllocations(subscriptionId, prepaidComponent.getId(), null)
+        ).isEmpty();
+    }
+
+    private static Long getServiceCreditsBalanceInCents(int subscriptionId) throws IOException, ApiException {
+        return SUBSCRIPTION_INVOICE_ACCOUNT_CONTROLLER.readAccountBalances(subscriptionId)
+                .getServiceCredits()
+                .getBalanceInCents();
+    }
+
+    private static List<CreditNote> getCreditNotesWithRefunds(int subscriptionId) throws ApiException, IOException {
+        return INVOICES_CONTROLLER
+                .listCreditNotes(new ListCreditNotesInput.Builder()
+                        .subscriptionId(subscriptionId)
+                        .refunds(true)
+                        .build()
+                )
+                .getCreditNotes();
+    }
+}

--- a/tests/src/test/java/com/maxio/advancedbilling/controllers/subscriptioncomponents/SubscriptionComponentsUpdatePrepaidAllocationExpirationDateTest.java
+++ b/tests/src/test/java/com/maxio/advancedbilling/controllers/subscriptioncomponents/SubscriptionComponentsUpdatePrepaidAllocationExpirationDateTest.java
@@ -1,0 +1,195 @@
+package com.maxio.advancedbilling.controllers.subscriptioncomponents;
+
+import com.maxio.advancedbilling.TestClient;
+import com.maxio.advancedbilling.controllers.SubscriptionComponentsController;
+import com.maxio.advancedbilling.exceptions.ApiException;
+import com.maxio.advancedbilling.exceptions.SubscriptionComponentAllocationErrorException;
+import com.maxio.advancedbilling.models.Allocation;
+import com.maxio.advancedbilling.models.AllocationExpirationDate;
+import com.maxio.advancedbilling.models.AllocationResponse;
+import com.maxio.advancedbilling.models.Component;
+import com.maxio.advancedbilling.models.CreateAllocation;
+import com.maxio.advancedbilling.models.CreateAllocationRequest;
+import com.maxio.advancedbilling.models.Customer;
+import com.maxio.advancedbilling.models.IntervalUnit;
+import com.maxio.advancedbilling.models.ProductFamily;
+import com.maxio.advancedbilling.models.Subscription;
+import com.maxio.advancedbilling.models.SubscriptionComponentAllocationErrorItem;
+import com.maxio.advancedbilling.models.UpdateAllocationExpirationDate;
+import com.maxio.advancedbilling.utils.TestSetup;
+import com.maxio.advancedbilling.utils.TestTeardown;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
+
+import static com.maxio.advancedbilling.utils.assertions.CommonAssertions.assertNotFound;
+import static com.maxio.advancedbilling.utils.assertions.CommonAssertions.assertUnauthorized;
+import static com.maxio.advancedbilling.utils.assertions.CommonAssertions.assertUnprocessableEntity;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubscriptionComponentsUpdatePrepaidAllocationExpirationDateTest {
+    private static final TestSetup TEST_SETUP = new TestSetup();
+    private static final SubscriptionComponentsController SUBSCRIPTION_COMPONENTS_CONTROLLER =
+            TestClient.createClient().getSubscriptionComponentsController();
+
+    private static Component prepaidComponent;
+    private static Allocation allocation;
+    private static Customer customer;
+    private static Subscription subscription;
+
+    @BeforeAll
+    static void setup() throws IOException, ApiException {
+        ProductFamily productFamily = TEST_SETUP.createProductFamily();
+        customer = TEST_SETUP.createCustomer();
+        prepaidComponent = TEST_SETUP.createPrepaidComponent(productFamily, customizer -> customizer
+                .rolloverPrepaidRemainder(true)
+                .expirationIntervalUnit(IntervalUnit.DAY)
+                .expirationInterval(10.0)
+        );
+        subscription = TEST_SETUP.createSubscription(customer, TEST_SETUP.createProduct(productFamily));
+        allocation = SUBSCRIPTION_COMPONENTS_CONTROLLER.allocateComponent(
+                subscription.getId(),
+                prepaidComponent.getId(),
+                new CreateAllocationRequest(new CreateAllocation.Builder()
+                        .quantity(10.0)
+                        .memo("Recoding component allocation")
+                        .build()
+                )
+        ).getAllocation();
+    }
+
+    @AfterAll
+    static void teardown() throws IOException, ApiException {
+        new TestTeardown().deleteCustomer(customer);
+    }
+
+    @Test
+    void shouldUpdatePrepaidUsageAllocationExpirationDate() throws IOException, ApiException {
+        // given
+        ZonedDateTime updatedExpiresAt = ZonedDateTime.now().plusMonths(2);
+
+        // when
+        SUBSCRIPTION_COMPONENTS_CONTROLLER.updatePrepaidUsageAllocationExpirationDate(
+                subscription.getId(),
+                prepaidComponent.getId(),
+                allocation.getAllocationId(),
+                // changing from 10 days to 2 months
+                new UpdateAllocationExpirationDate(new AllocationExpirationDate(updatedExpiresAt))
+        );
+
+        // then
+        assertThat(SUBSCRIPTION_COMPONENTS_CONTROLLER.listAllocations(
+                subscription.getId(), prepaidComponent.getId(), null)
+        )
+                .hasSize(1)
+                .singleElement()
+                .extracting(AllocationResponse::getAllocation)
+                .extracting(Allocation::getExpiresAt)
+                .satisfies(actualExpiration -> assertThat(actualExpiration.toInstant())
+                        .isEqualTo(updatedExpiresAt.toInstant().truncatedTo(ChronoUnit.SECONDS))
+                );
+    }
+
+    @ParameterizedTest
+    @MethodSource("argsForShouldReturn404ForNotExistentResources")
+    void shouldReturn404ForNotExistentResources(int subscriptionId, int componentId, int allocationId) {
+        // when - then
+        assertNotFound(() -> SUBSCRIPTION_COMPONENTS_CONTROLLER.updatePrepaidUsageAllocationExpirationDate(
+                subscriptionId,
+                componentId,
+                allocationId,
+                new UpdateAllocationExpirationDate(new AllocationExpirationDate(ZonedDateTime.now().plusDays(5)))
+        ));
+    }
+
+    private static Stream<Arguments> argsForShouldReturn404ForNotExistentResources() {
+        return Stream.of(
+                Arguments.arguments(subscription.getId(), prepaidComponent.getId(), 123),
+                Arguments.arguments(subscription.getId(), 123, allocation.getAllocationId()),
+                Arguments.arguments(123, prepaidComponent.getId(), allocation.getAllocationId()),
+                Arguments.arguments(111, 222, 333)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("argsForShouldReturn422WhenRequestBodyIsIncorrect")
+    void shouldReturn422WhenRequestBodyIsIncorrect(UpdateAllocationExpirationDate request,
+                                                   SubscriptionComponentAllocationErrorItem... expectedErrors) {
+        // when - then
+        assertUnprocessableEntity(
+                SubscriptionComponentAllocationErrorException.class,
+                () -> SUBSCRIPTION_COMPONENTS_CONTROLLER.updatePrepaidUsageAllocationExpirationDate(
+                        subscription.getId(),
+                        prepaidComponent.getId(),
+                        allocation.getAllocationId(),
+                        request
+                ),
+                e -> assertThat(e.getErrors())
+                        .usingRecursiveFieldByFieldElementComparator()
+                        .containsExactlyInAnyOrder(expectedErrors)
+        );
+    }
+
+    private static Stream<Arguments> argsForShouldReturn422WhenRequestBodyIsIncorrect() {
+        return Stream.of(
+                Arguments.arguments(
+                        // request body
+                        new UpdateAllocationExpirationDate(),
+                        // expected errors
+                        new SubscriptionComponentAllocationErrorItem[]{
+                                new SubscriptionComponentAllocationErrorItem.Builder()
+                                        .kind("base")
+                                        .message("A valid expires_at date must be provided.")
+                                        .build()
+                        }
+                ),
+                Arguments.arguments(
+                        // request body
+                        new UpdateAllocationExpirationDate(
+                                new AllocationExpirationDate()
+                        ),
+                        // expected errors
+                        new SubscriptionComponentAllocationErrorItem[]{
+                                new SubscriptionComponentAllocationErrorItem.Builder()
+                                        .kind("base")
+                                        .message("A valid expires_at date must be provided.")
+                                        .build()
+                        }
+                ),
+                Arguments.arguments(
+                        // request body
+                        new UpdateAllocationExpirationDate(
+                                new AllocationExpirationDate(ZonedDateTime.now().minusMonths(1))
+                        ),
+                        // expected errors
+                        new SubscriptionComponentAllocationErrorItem[]{
+                                new SubscriptionComponentAllocationErrorItem.Builder()
+                                        .kind("base")
+                                        .message("Expires at: must be greater than or equal to %s".formatted(ZonedDateTime.now().toLocalDate()))
+                                        .build()
+                        }
+                )
+        );
+    }
+
+    @Test
+    void shouldNotBulkResetWhenProvidingInvalidCredentials() {
+        // when - then
+        assertUnauthorized(() -> TestClient.createInvalidCredentialsClient().getSubscriptionComponentsController()
+                .updatePrepaidUsageAllocationExpirationDate(
+                        subscription.getId(),
+                        prepaidComponent.getId(),
+                        allocation.getAllocationId(),
+                        new UpdateAllocationExpirationDate()
+                )
+        );
+    }
+}


### PR DESCRIPTION
Tests for endpoints:
- `bulkResetSubscriptionComponentsPricePoints`
- `bulkUpdateSubscriptionComponentsPricePoints`
- `deletePrepaidUsageAllocation`
- `updatePrepaidUsageAllocationExpirationDate`