### PR TITLE
[DE-1068][DE-1024] Sort out environments, fix EBB endpoints, add `processing` Invoice Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,6 @@ AdvancedBillingClient client = new AdvancedBillingClient.Builder()
     .build();
 ```
 
-## Environments
-
-The SDK can be configured to use a different environment for making API calls. Available environments are:
-
-### Fields
-
-| Name | Description |
-|  --- | --- |
-| production | **Default** Production server |
-| environment2 | Production server |
-
 ## Authorization
 
 This API uses the following authentication schemes.

--- a/doc/controllers/subscription-components.md
+++ b/doc/controllers/subscription-components.md
@@ -1417,7 +1417,6 @@ https://events.chargify.com/my-site-subdomain/events/my-stream-api-handle
 
 ```java
 Void recordEvent(
-    final String subdomain,
     final String apiHandle,
     final String storeUid,
     final EBBEvent body)
@@ -1427,10 +1426,13 @@ Void recordEvent(
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `subdomain` | `String` | Template, Required | Your site's subdomain |
 | `apiHandle` | `String` | Template, Required | Identifies the Stream for which the event should be published. |
 | `storeUid` | `String` | Query, Optional | If you've attached your own Keen project as an Advanced Billing event data-store, use this parameter to indicate the data-store. |
 | `body` | [`EBBEvent`](../../doc/models/ebb-event.md) | Body, Optional | - |
+
+## Server
+
+`Server.EBB`
 
 ## Response Type
 
@@ -1439,7 +1441,6 @@ Void recordEvent(
 ## Example Usage
 
 ```java
-String subdomain = "subdomain4";
 String apiHandle = "api_handle6";
 EBBEvent body = new EBBEvent.Builder()
     .chargify(new ChargifyEBB.Builder()
@@ -1449,7 +1450,7 @@ EBBEvent body = new EBBEvent.Builder()
     .build();
 
 try {
-    subscriptionComponentsController.recordEvent(subdomain, apiHandle, null, body);
+    subscriptionComponentsController.recordEvent(apiHandle, null, body);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -1468,7 +1469,6 @@ A maximum of 1000 events can be published in a single request. A 422 will be ret
 
 ```java
 Void bulkRecordEvents(
-    final String subdomain,
     final String apiHandle,
     final String storeUid,
     final List<EBBEvent> body)
@@ -1478,10 +1478,13 @@ Void bulkRecordEvents(
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `subdomain` | `String` | Template, Required | Your site's subdomain |
 | `apiHandle` | `String` | Template, Required | Identifies the Stream for which the events should be published. |
 | `storeUid` | `String` | Query, Optional | If you've attached your own Keen project as an Advanced Billing event data-store, use this parameter to indicate the data-store. |
 | `body` | [`List<EBBEvent>`](../../doc/models/ebb-event.md) | Body, Optional | - |
+
+## Server
+
+`Server.EBB`
 
 ## Response Type
 
@@ -1490,7 +1493,6 @@ Void bulkRecordEvents(
 ## Example Usage
 
 ```java
-String subdomain = "subdomain4";
 String apiHandle = "api_handle6";
 List<EBBEvent> body = Arrays.asList(
     new EBBEvent.Builder()
@@ -1502,7 +1504,7 @@ List<EBBEvent> body = Arrays.asList(
 );
 
 try {
-    subscriptionComponentsController.bulkRecordEvents(subdomain, apiHandle, null, body);
+    subscriptionComponentsController.bulkRecordEvents(apiHandle, null, body);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {

--- a/doc/models/change-invoice-status-event-data.md
+++ b/doc/models/change-invoice-status-event-data.md
@@ -24,7 +24,7 @@ Example schema for an `change_invoice_status` event
   "gateway_trans_id": "gateway_trans_id2",
   "amount": "amount2",
   "from_status": "draft",
-  "to_status": "paid",
+  "to_status": "pending",
   "consolidation_level": "none"
 }
 ```

--- a/doc/models/change-invoice-status-event.md
+++ b/doc/models/change-invoice-status-event.md
@@ -36,8 +36,8 @@
   "event_data": {
     "gateway_trans_id": "gateway_trans_id2",
     "amount": "amount8",
-    "from_status": "paid",
-    "to_status": "paid",
+    "from_status": "open",
+    "to_status": "pending",
     "consolidation_level": "child"
   }
 }

--- a/doc/models/invoice-status.md
+++ b/doc/models/invoice-status.md
@@ -17,4 +17,5 @@ The current status of the invoice. See [Invoice Statuses](https://maxio.zendesk.
 | `Pending` |
 | `Voided` |
 | `Canceled` |
+| `Processing` |
 

--- a/doc/models/issue-invoice-event-data.md
+++ b/doc/models/issue-invoice-event-data.md
@@ -22,8 +22,8 @@ Example schema for an `issue_invoice` event
 ```json
 {
   "consolidation_level": "none",
-  "from_status": "draft",
-  "to_status": "voided",
+  "from_status": "voided",
+  "to_status": "draft",
   "due_amount": "due_amount6",
   "total_amount": "total_amount0"
 }

--- a/doc/models/issue-invoice-event.md
+++ b/doc/models/issue-invoice-event.md
@@ -35,8 +35,8 @@
   "event_type": "issue_invoice",
   "event_data": {
     "consolidation_level": "child",
-    "from_status": "paid",
-    "to_status": "paid",
+    "from_status": "open",
+    "to_status": "pending",
     "due_amount": "due_amount8",
     "total_amount": "total_amount2"
   }

--- a/doc/models/paid-invoice.md
+++ b/doc/models/paid-invoice.md
@@ -19,7 +19,7 @@
 ```json
 {
   "invoice_id": "invoice_id6",
-  "status": "draft",
+  "status": "open",
   "due_amount": "due_amount8",
   "paid_amount": "paid_amount8"
 }

--- a/src/main/java/com/maxio/advancedbilling/AdvancedBillingClient.java
+++ b/src/main/java/com/maxio/advancedbilling/AdvancedBillingClient.java
@@ -554,7 +554,7 @@ public final class AdvancedBillingClient implements Configuration {
      * @return Processed base URI
      */
     public String getBaseUri() {
-        return getBaseUri(Server.ENUM_DEFAULT);
+        return getBaseUri(Server.PRODUCTION);
     }
 
 
@@ -577,13 +577,11 @@ public final class AdvancedBillingClient implements Configuration {
      */
     private static String environmentMapper(Environment environment, Server server) {
         if (environment.equals(Environment.PRODUCTION)) {
-            if (server.equals(Server.ENUM_DEFAULT)) {
+            if (server.equals(Server.PRODUCTION)) {
                 return "https://{subdomain}.{domain}";
             }
-        }
-        if (environment.equals(Environment.ENVIRONMENT2)) {
-            if (server.equals(Server.ENUM_DEFAULT)) {
-                return "https://events.chargify.com";
+            if (server.equals(Server.EBB)) {
+                return "https://events.{domain}/{subdomain}";
             }
         }
         return "https://{subdomain}.{domain}";

--- a/src/main/java/com/maxio/advancedbilling/Environment.java
+++ b/src/main/java/com/maxio/advancedbilling/Environment.java
@@ -17,15 +17,7 @@ import java.util.TreeMap;
  * Environment to be used.
  */
 public enum Environment {
-    /**
-     * Production server
-     */
-    PRODUCTION,
-
-    /**
-     * Production server
-     */
-    ENVIRONMENT2;
+    PRODUCTION;
 
 
     private static TreeMap<String, Environment> valueMap = new TreeMap<>();
@@ -33,10 +25,8 @@ public enum Environment {
 
     static {
         PRODUCTION.value = "production";
-        ENVIRONMENT2.value = "environment2";
 
         valueMap.put("production", PRODUCTION);
-        valueMap.put("environment2", ENVIRONMENT2);
     }
 
     /**

--- a/src/main/java/com/maxio/advancedbilling/Server.java
+++ b/src/main/java/com/maxio/advancedbilling/Server.java
@@ -17,16 +17,20 @@ import java.util.TreeMap;
  * Server to be used.
  */
 public enum Server {
-    ENUM_DEFAULT;
+    PRODUCTION,
+
+    EBB;
 
 
     private static TreeMap<String, Server> valueMap = new TreeMap<>();
     private String value;
 
     static {
-        ENUM_DEFAULT.value = "default";
+        PRODUCTION.value = "production";
+        EBB.value = "ebb";
 
-        valueMap.put("default", ENUM_DEFAULT);
+        valueMap.put("production", PRODUCTION);
+        valueMap.put("ebb", EBB);
     }
 
     /**

--- a/src/main/java/com/maxio/advancedbilling/controllers/APIExportsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/APIExportsController.java
@@ -60,7 +60,7 @@ public final class APIExportsController extends BaseController {
         return new ApiCall.Builder<List<ProformaInvoice>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/api_exports/proforma_invoices/{batch_id}/rows.json")
                         .queryParam(param -> param.key("per_page")
                                 .value(input.getPerPage()).isRequired(false))
@@ -107,7 +107,7 @@ public final class APIExportsController extends BaseController {
         return new ApiCall.Builder<List<Invoice>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/api_exports/invoices/{batch_id}/rows.json")
                         .queryParam(param -> param.key("per_page")
                                 .value(input.getPerPage()).isRequired(false))
@@ -154,7 +154,7 @@ public final class APIExportsController extends BaseController {
         return new ApiCall.Builder<List<Subscription>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/api_exports/subscriptions/{batch_id}/rows.json")
                         .queryParam(param -> param.key("per_page")
                                 .value(input.getPerPage()).isRequired(false))
@@ -197,7 +197,7 @@ public final class APIExportsController extends BaseController {
         return new ApiCall.Builder<BatchJobResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/api_exports/proforma_invoices.json")
                         .headerParam(param -> param.key("accept").value("application/json"))
                         .withAuth(auth -> auth
@@ -235,7 +235,7 @@ public final class APIExportsController extends BaseController {
         return new ApiCall.Builder<BatchJobResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/api_exports/invoices.json")
                         .headerParam(param -> param.key("accept").value("application/json"))
                         .withAuth(auth -> auth
@@ -273,7 +273,7 @@ public final class APIExportsController extends BaseController {
         return new ApiCall.Builder<BatchJobResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/api_exports/subscriptions.json")
                         .headerParam(param -> param.key("accept").value("application/json"))
                         .withAuth(auth -> auth
@@ -311,7 +311,7 @@ public final class APIExportsController extends BaseController {
         return new ApiCall.Builder<BatchJobResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/api_exports/proforma_invoices/{batch_id}.json")
                         .templateParam(param -> param.key("batch_id").value(batchId)
                                 .shouldEncode(true))
@@ -351,7 +351,7 @@ public final class APIExportsController extends BaseController {
         return new ApiCall.Builder<BatchJobResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/api_exports/invoices/{batch_id}.json")
                         .templateParam(param -> param.key("batch_id").value(batchId)
                                 .shouldEncode(true))
@@ -391,7 +391,7 @@ public final class APIExportsController extends BaseController {
         return new ApiCall.Builder<BatchJobResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/api_exports/subscriptions/{batch_id}.json")
                         .templateParam(param -> param.key("batch_id").value(batchId)
                                 .shouldEncode(true))

--- a/src/main/java/com/maxio/advancedbilling/controllers/AdvanceInvoiceController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/AdvanceInvoiceController.java
@@ -67,7 +67,7 @@ public final class AdvanceInvoiceController extends BaseController {
         return new ApiCall.Builder<Invoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/advance_invoice/issue.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -116,7 +116,7 @@ public final class AdvanceInvoiceController extends BaseController {
         return new ApiCall.Builder<Invoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/advance_invoice.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))
@@ -163,7 +163,7 @@ public final class AdvanceInvoiceController extends BaseController {
         return new ApiCall.Builder<Invoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/advance_invoice/void.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))

--- a/src/main/java/com/maxio/advancedbilling/controllers/BillingPortalController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/BillingPortalController.java
@@ -77,7 +77,7 @@ public final class BillingPortalController extends BaseController {
         return new ApiCall.Builder<CustomerResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/portal/customers/{customer_id}/enable.json")
                         .queryParam(param -> param.key("auto_invite")
                                 .value((autoInvite != null) ? autoInvite.value() : null).isRequired(false))
@@ -126,7 +126,7 @@ public final class BillingPortalController extends BaseController {
         return new ApiCall.Builder<PortalManagementLink, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/portal/customers/{customer_id}/management_link.json")
                         .templateParam(param -> param.key("customer_id").value(customerId).isRequired(false)
                                 .shouldEncode(true))
@@ -176,7 +176,7 @@ public final class BillingPortalController extends BaseController {
         return new ApiCall.Builder<ResentInvitation, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/portal/customers/{customer_id}/invitations/invite.json")
                         .templateParam(param -> param.key("customer_id").value(customerId).isRequired(false)
                                 .shouldEncode(true))
@@ -221,7 +221,7 @@ public final class BillingPortalController extends BaseController {
         return new ApiCall.Builder<RevokedInvitation, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/portal/customers/{customer_id}/invitations/revoke.json")
                         .templateParam(param -> param.key("customer_id").value(customerId).isRequired(false)
                                 .shouldEncode(true))

--- a/src/main/java/com/maxio/advancedbilling/controllers/ComponentPricePointsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/ComponentPricePointsController.java
@@ -81,7 +81,7 @@ public final class ComponentPricePointsController extends BaseController {
         return new ApiCall.Builder<ComponentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}/price_points/{price_point_id}/default.json")
                         .templateParam(param -> param.key("component_id").value(componentId).isRequired(false)
                                 .shouldEncode(true))
@@ -123,7 +123,7 @@ public final class ComponentPricePointsController extends BaseController {
         return new ApiCall.Builder<ComponentPricePointResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}/price_points.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -170,7 +170,7 @@ public final class ComponentPricePointsController extends BaseController {
         return new ApiCall.Builder<ComponentPricePointsResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}/price_points.json")
                         .queryParam(param -> param.key("currency_prices")
                                 .value(input.getCurrencyPrices()).isRequired(false))
@@ -219,7 +219,7 @@ public final class ComponentPricePointsController extends BaseController {
         return new ApiCall.Builder<ComponentPricePointsResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}/price_points/bulk.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -274,7 +274,7 @@ public final class ComponentPricePointsController extends BaseController {
         return new ApiCall.Builder<ComponentPricePointResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}/price_points/{price_point_id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -332,7 +332,7 @@ public final class ComponentPricePointsController extends BaseController {
         return new ApiCall.Builder<ComponentPricePointResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}/price_points/{price_point_id}.json")
                         .queryParam(param -> param.key("currency_prices")
                                 .value(currencyPrices).isRequired(false))
@@ -381,7 +381,7 @@ public final class ComponentPricePointsController extends BaseController {
         return new ApiCall.Builder<ComponentPricePointResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}/price_points/{price_point_id}.json")
                         .templateParam(param -> param.key("component_id").value(componentId)
                                 .shouldEncode(true))
@@ -427,7 +427,7 @@ public final class ComponentPricePointsController extends BaseController {
         return new ApiCall.Builder<ComponentPricePointResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}/price_points/{price_point_id}/unarchive.json")
                         .templateParam(param -> param.key("component_id").value(componentId).isRequired(false)
                                 .shouldEncode(true))
@@ -473,7 +473,7 @@ public final class ComponentPricePointsController extends BaseController {
         return new ApiCall.Builder<ComponentCurrencyPricesResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/price_points/{price_point_id}/currency_prices.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -522,7 +522,7 @@ public final class ComponentPricePointsController extends BaseController {
         return new ApiCall.Builder<ComponentCurrencyPricesResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/price_points/{price_point_id}/currency_prices.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -566,7 +566,7 @@ public final class ComponentPricePointsController extends BaseController {
         return new ApiCall.Builder<ListComponentsPricePointsResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components_price_points.json")
                         .queryParam(param -> param.key("include")
                                 .value((input.getInclude() != null) ? input.getInclude().value() : null).isRequired(false))

--- a/src/main/java/com/maxio/advancedbilling/controllers/ComponentsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/ComponentsController.java
@@ -75,7 +75,7 @@ public final class ComponentsController extends BaseController {
         return new ApiCall.Builder<ComponentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/metered_components.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -137,7 +137,7 @@ public final class ComponentsController extends BaseController {
         return new ApiCall.Builder<ComponentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/quantity_based_components.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -193,7 +193,7 @@ public final class ComponentsController extends BaseController {
         return new ApiCall.Builder<ComponentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/on_off_components.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -252,7 +252,7 @@ public final class ComponentsController extends BaseController {
         return new ApiCall.Builder<ComponentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/prepaid_usage_components.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -312,7 +312,7 @@ public final class ComponentsController extends BaseController {
         return new ApiCall.Builder<ComponentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/event_based_components.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -361,7 +361,7 @@ public final class ComponentsController extends BaseController {
         return new ApiCall.Builder<ComponentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/lookup.json")
                         .queryParam(param -> param.key("handle")
                                 .value(handle))
@@ -405,7 +405,7 @@ public final class ComponentsController extends BaseController {
         return new ApiCall.Builder<ComponentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/components/{component_id}.json")
                         .templateParam(param -> param.key("product_family_id").value(productFamilyId).isRequired(false)
                                 .shouldEncode(true))
@@ -455,7 +455,7 @@ public final class ComponentsController extends BaseController {
         return new ApiCall.Builder<ComponentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/components/{component_id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -507,7 +507,7 @@ public final class ComponentsController extends BaseController {
         return new ApiCall.Builder<Component, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/components/{component_id}.json")
                         .templateParam(param -> param.key("product_family_id").value(productFamilyId).isRequired(false)
                                 .shouldEncode(true))
@@ -549,7 +549,7 @@ public final class ComponentsController extends BaseController {
         return new ApiCall.Builder<List<ComponentResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components.json")
                         .queryParam(param -> param.key("date_field")
                                 .value((input.getDateField() != null) ? input.getDateField().value() : null).isRequired(false))
@@ -607,7 +607,7 @@ public final class ComponentsController extends BaseController {
         return new ApiCall.Builder<ComponentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -651,7 +651,7 @@ public final class ComponentsController extends BaseController {
         return new ApiCall.Builder<List<ComponentResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/components.json")
                         .queryParam(param -> param.key("include_archived")
                                 .value(input.getIncludeArchived()).isRequired(false))

--- a/src/main/java/com/maxio/advancedbilling/controllers/CouponsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/CouponsController.java
@@ -77,7 +77,7 @@ public final class CouponsController extends BaseController {
         return new ApiCall.Builder<CouponResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/coupons.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -123,7 +123,7 @@ public final class CouponsController extends BaseController {
         return new ApiCall.Builder<List<CouponResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/coupons.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -183,7 +183,7 @@ public final class CouponsController extends BaseController {
         return new ApiCall.Builder<CouponResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/coupons/find.json")
                         .queryParam(param -> param.key("product_family_id")
                                 .value(productFamilyId).isRequired(false))
@@ -241,7 +241,7 @@ public final class CouponsController extends BaseController {
         return new ApiCall.Builder<CouponResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/coupons/{coupon_id}.json")
                         .queryParam(param -> param.key("currency_prices")
                                 .value(currencyPrices).isRequired(false))
@@ -292,7 +292,7 @@ public final class CouponsController extends BaseController {
         return new ApiCall.Builder<CouponResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/coupons/{coupon_id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -344,7 +344,7 @@ public final class CouponsController extends BaseController {
         return new ApiCall.Builder<CouponResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/coupons/{coupon_id}.json")
                         .templateParam(param -> param.key("product_family_id").value(productFamilyId).isRequired(false)
                                 .shouldEncode(true))
@@ -385,7 +385,7 @@ public final class CouponsController extends BaseController {
         return new ApiCall.Builder<List<CouponResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/coupons.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -434,7 +434,7 @@ public final class CouponsController extends BaseController {
         return new ApiCall.Builder<List<CouponUsage>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/coupons/{coupon_id}/usage.json")
                         .templateParam(param -> param.key("product_family_id").value(productFamilyId).isRequired(false)
                                 .shouldEncode(true))
@@ -491,7 +491,7 @@ public final class CouponsController extends BaseController {
         return new ApiCall.Builder<CouponResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/coupons/validate.json")
                         .queryParam(param -> param.key("code")
                                 .value(code))
@@ -541,7 +541,7 @@ public final class CouponsController extends BaseController {
         return new ApiCall.Builder<CouponCurrencyResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/coupons/{coupon_id}/currency_prices.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -602,7 +602,7 @@ public final class CouponsController extends BaseController {
         return new ApiCall.Builder<CouponSubcodesResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/coupons/{coupon_id}/codes.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -643,7 +643,7 @@ public final class CouponsController extends BaseController {
         return new ApiCall.Builder<CouponSubcodes, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/coupons/{coupon_id}/codes.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -691,7 +691,7 @@ public final class CouponsController extends BaseController {
         return new ApiCall.Builder<CouponSubcodesResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/coupons/{coupon_id}/codes.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -742,7 +742,7 @@ public final class CouponsController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/coupons/{coupon_id}/codes/{subcode}.json")
                         .templateParam(param -> param.key("coupon_id").value(couponId).isRequired(false)
                                 .shouldEncode(true))

--- a/src/main/java/com/maxio/advancedbilling/controllers/CustomFieldsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/CustomFieldsController.java
@@ -91,7 +91,7 @@ public final class CustomFieldsController extends BaseController {
         return new ApiCall.Builder<List<Metafield>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/{resource_type}/metafields.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -137,7 +137,7 @@ public final class CustomFieldsController extends BaseController {
         return new ApiCall.Builder<ListMetafieldsResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/{resource_type}/metafields.json")
                         .queryParam(param -> param.key("name")
                                 .value(input.getName()).isRequired(false))
@@ -186,7 +186,7 @@ public final class CustomFieldsController extends BaseController {
         return new ApiCall.Builder<List<Metafield>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/{resource_type}/metafields.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -235,7 +235,7 @@ public final class CustomFieldsController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/{resource_type}/metafields.json")
                         .queryParam(param -> param.key("name")
                                 .value(name).isRequired(false))
@@ -299,7 +299,7 @@ public final class CustomFieldsController extends BaseController {
         return new ApiCall.Builder<List<Metadata>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/{resource_type}/{resource_id}/metadata.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -348,7 +348,7 @@ public final class CustomFieldsController extends BaseController {
         return new ApiCall.Builder<PaginatedMetadata, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/{resource_type}/{resource_id}/metadata.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -399,7 +399,7 @@ public final class CustomFieldsController extends BaseController {
         return new ApiCall.Builder<List<Metadata>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/{resource_type}/{resource_id}/metadata.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -463,7 +463,7 @@ public final class CustomFieldsController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/{resource_type}/{resource_id}/metadata.json")
                         .queryParam(param -> param.key("name")
                                 .value(name).isRequired(false))
@@ -511,7 +511,7 @@ public final class CustomFieldsController extends BaseController {
         return new ApiCall.Builder<PaginatedMetadata, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/{resource_type}/metadata.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))

--- a/src/main/java/com/maxio/advancedbilling/controllers/CustomersController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/CustomersController.java
@@ -78,7 +78,7 @@ public final class CustomersController extends BaseController {
         return new ApiCall.Builder<CustomerResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/customers.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -126,7 +126,7 @@ public final class CustomersController extends BaseController {
         return new ApiCall.Builder<List<CustomerResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/customers.json")
                         .queryParam(param -> param.key("direction")
                                 .value((input.getDirection() != null) ? input.getDirection().value() : null).isRequired(false))
@@ -181,7 +181,7 @@ public final class CustomersController extends BaseController {
         return new ApiCall.Builder<CustomerResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/customers/{id}.json")
                         .templateParam(param -> param.key("id").value(id).isRequired(false)
                                 .shouldEncode(true))
@@ -221,7 +221,7 @@ public final class CustomersController extends BaseController {
         return new ApiCall.Builder<CustomerResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/customers/{id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -267,7 +267,7 @@ public final class CustomersController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/customers/{id}.json")
                         .templateParam(param -> param.key("id").value(id).isRequired(false)
                                 .shouldEncode(true))
@@ -302,7 +302,7 @@ public final class CustomersController extends BaseController {
         return new ApiCall.Builder<CustomerResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/customers/lookup.json")
                         .queryParam(param -> param.key("reference")
                                 .value(reference))
@@ -339,7 +339,7 @@ public final class CustomersController extends BaseController {
         return new ApiCall.Builder<List<SubscriptionResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/customers/{customer_id}/subscriptions.json")
                         .templateParam(param -> param.key("customer_id").value(customerId).isRequired(false)
                                 .shouldEncode(true))

--- a/src/main/java/com/maxio/advancedbilling/controllers/EventsBasedBillingSegmentsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/EventsBasedBillingSegmentsController.java
@@ -70,7 +70,7 @@ public final class EventsBasedBillingSegmentsController extends BaseController {
         return new ApiCall.Builder<SegmentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}/price_points/{price_point_id}/segments.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -123,7 +123,7 @@ public final class EventsBasedBillingSegmentsController extends BaseController {
         return new ApiCall.Builder<ListSegmentsResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}/price_points/{price_point_id}/segments.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -186,7 +186,7 @@ public final class EventsBasedBillingSegmentsController extends BaseController {
         return new ApiCall.Builder<SegmentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}/price_points/{price_point_id}/segments/{id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -244,7 +244,7 @@ public final class EventsBasedBillingSegmentsController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}/price_points/{price_point_id}/segments/{id}.json")
                         .templateParam(param -> param.key("component_id").value(componentId)
                                 .shouldEncode(true))
@@ -300,7 +300,7 @@ public final class EventsBasedBillingSegmentsController extends BaseController {
         return new ApiCall.Builder<ListSegmentsResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}/price_points/{price_point_id}/segments/bulk.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -361,7 +361,7 @@ public final class EventsBasedBillingSegmentsController extends BaseController {
         return new ApiCall.Builder<ListSegmentsResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/components/{component_id}/price_points/{price_point_id}/segments/bulk.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))

--- a/src/main/java/com/maxio/advancedbilling/controllers/EventsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/EventsController.java
@@ -77,7 +77,7 @@ public final class EventsController extends BaseController {
         return new ApiCall.Builder<List<EventResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/events.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -136,7 +136,7 @@ public final class EventsController extends BaseController {
         return new ApiCall.Builder<List<EventResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/events.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -186,7 +186,7 @@ public final class EventsController extends BaseController {
         return new ApiCall.Builder<CountResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/events/count.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))

--- a/src/main/java/com/maxio/advancedbilling/controllers/InsightsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/InsightsController.java
@@ -59,7 +59,7 @@ public final class InsightsController extends BaseController {
         return new ApiCall.Builder<SiteSummary, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/stats.json")
                         .headerParam(param -> param.key("accept").value("application/json"))
                         .withAuth(auth -> auth
@@ -102,7 +102,7 @@ public final class InsightsController extends BaseController {
         return new ApiCall.Builder<MRRResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/mrr.json")
                         .queryParam(param -> param.key("at_time")
                                 .value(DateTimeHelper.toRfc8601DateTime(atTime)).isRequired(false))
@@ -156,7 +156,7 @@ public final class InsightsController extends BaseController {
         return new ApiCall.Builder<ListMRRResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/mrr_movements.json")
                         .queryParam(param -> param.key("subscription_id")
                                 .value(input.getSubscriptionId()).isRequired(false))
@@ -203,7 +203,7 @@ public final class InsightsController extends BaseController {
         return new ApiCall.Builder<SubscriptionMRRResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions_mrr.json")
                         .queryParam(param -> param.key("filter")
                                 .value(input.getFilter()).isRequired(false))

--- a/src/main/java/com/maxio/advancedbilling/controllers/InvoicesController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/InvoicesController.java
@@ -82,7 +82,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<Invoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/invoices/{uid}/refunds.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -129,7 +129,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<ListInvoicesResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/invoices.json")
                         .queryParam(param -> param.key("start_date")
                                 .value(input.getStartDate()).isRequired(false))
@@ -214,7 +214,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<Invoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/invoices/{uid}.json")
                         .templateParam(param -> param.key("uid").value(uid)
                                 .shouldEncode(true))
@@ -259,7 +259,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<ListInvoiceEventsResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/invoices/events.json")
                         .queryParam(param -> param.key("since_date")
                                 .value(input.getSinceDate()).isRequired(false))
@@ -329,7 +329,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<Invoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/invoices/{uid}/payments.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -380,7 +380,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<MultiInvoicePaymentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/invoices/payments.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -425,7 +425,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<ListCreditNotesResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/credit_notes.json")
                         .queryParam(param -> param.key("subscription_id")
                                 .value(input.getSubscriptionId()).isRequired(false))
@@ -476,7 +476,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<CreditNote, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/credit_notes/{uid}.json")
                         .templateParam(param -> param.key("uid").value(uid)
                                 .shouldEncode(true))
@@ -520,7 +520,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<RecordPaymentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/payments.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -576,7 +576,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<Invoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/invoices/{uid}/reopen.json")
                         .templateParam(param -> param.key("uid").value(uid)
                                 .shouldEncode(true))
@@ -625,7 +625,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<Invoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/invoices/{uid}/void.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -673,7 +673,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<ConsolidatedInvoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/invoices/{invoice_uid}/segments.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -786,7 +786,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<InvoiceResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/invoices.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -843,7 +843,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/invoices/{uid}/deliveries.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -889,7 +889,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<CustomerChangesPreviewResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/invoices/{uid}/customer_information/preview.json")
                         .templateParam(param -> param.key("uid").value(uid)
                                 .shouldEncode(true))
@@ -937,7 +937,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<Invoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/invoices/{uid}/customer_information.json")
                         .templateParam(param -> param.key("uid").value(uid)
                                 .shouldEncode(true))
@@ -1002,7 +1002,7 @@ public final class InvoicesController extends BaseController {
         return new ApiCall.Builder<Invoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/invoices/{uid}/issue.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))

--- a/src/main/java/com/maxio/advancedbilling/controllers/OffersController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/OffersController.java
@@ -63,7 +63,7 @@ public final class OffersController extends BaseController {
         return new ApiCall.Builder<OfferResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/offers.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -105,7 +105,7 @@ public final class OffersController extends BaseController {
         return new ApiCall.Builder<ListOffersResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/offers.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -147,7 +147,7 @@ public final class OffersController extends BaseController {
         return new ApiCall.Builder<OfferResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/offers/{offer_id}.json")
                         .templateParam(param -> param.key("offer_id").value(offerId).isRequired(false)
                                 .shouldEncode(true))
@@ -183,7 +183,7 @@ public final class OffersController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/offers/{offer_id}/archive.json")
                         .templateParam(param -> param.key("offer_id").value(offerId).isRequired(false)
                                 .shouldEncode(true))
@@ -217,7 +217,7 @@ public final class OffersController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/offers/{offer_id}/unarchive.json")
                         .templateParam(param -> param.key("offer_id").value(offerId).isRequired(false)
                                 .shouldEncode(true))

--- a/src/main/java/com/maxio/advancedbilling/controllers/PaymentProfilesController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/PaymentProfilesController.java
@@ -202,7 +202,7 @@ public final class PaymentProfilesController extends BaseController {
         return new ApiCall.Builder<PaymentProfileResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/payment_profiles.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -249,7 +249,7 @@ public final class PaymentProfilesController extends BaseController {
         return new ApiCall.Builder<List<PaymentProfileResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/payment_profiles.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -301,7 +301,7 @@ public final class PaymentProfilesController extends BaseController {
         return new ApiCall.Builder<PaymentProfileResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/payment_profiles/{payment_profile_id}.json")
                         .templateParam(param -> param.key("payment_profile_id").value(paymentProfileId).isRequired(false)
                                 .shouldEncode(true))
@@ -365,7 +365,7 @@ public final class PaymentProfilesController extends BaseController {
         return new ApiCall.Builder<PaymentProfileResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/payment_profiles/{payment_profile_id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -412,7 +412,7 @@ public final class PaymentProfilesController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/payment_profiles/{payment_profile_id}.json")
                         .templateParam(param -> param.key("payment_profile_id").value(paymentProfileId).isRequired(false)
                                 .shouldEncode(true))
@@ -460,7 +460,7 @@ public final class PaymentProfilesController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/payment_profiles/{payment_profile_id}.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))
@@ -500,7 +500,7 @@ public final class PaymentProfilesController extends BaseController {
         return new ApiCall.Builder<BankAccountResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/bank_accounts/{bank_account_id}/verification.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -551,7 +551,7 @@ public final class PaymentProfilesController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}/payment_profiles/{payment_profile_id}.json")
                         .templateParam(param -> param.key("uid").value(uid)
                                 .shouldEncode(true))
@@ -593,7 +593,7 @@ public final class PaymentProfilesController extends BaseController {
         return new ApiCall.Builder<PaymentProfileResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/payment_profiles/{payment_profile_id}/change_payment_profile.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))
@@ -646,7 +646,7 @@ public final class PaymentProfilesController extends BaseController {
         return new ApiCall.Builder<PaymentProfileResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}/payment_profiles/{payment_profile_id}/change_payment_profile.json")
                         .templateParam(param -> param.key("uid").value(uid)
                                 .shouldEncode(true))
@@ -692,7 +692,7 @@ public final class PaymentProfilesController extends BaseController {
         return new ApiCall.Builder<GetOneTimeTokenRequest, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/one_time_tokens/{chargify_token}.json")
                         .templateParam(param -> param.key("chargify_token").value(chargifyToken)
                                 .shouldEncode(true))
@@ -741,7 +741,7 @@ public final class PaymentProfilesController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/request_payment_profiles_update.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))

--- a/src/main/java/com/maxio/advancedbilling/controllers/ProductFamiliesController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/ProductFamiliesController.java
@@ -57,7 +57,7 @@ public final class ProductFamiliesController extends BaseController {
         return new ApiCall.Builder<List<ProductResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/products.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -121,7 +121,7 @@ public final class ProductFamiliesController extends BaseController {
         return new ApiCall.Builder<ProductFamilyResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -163,7 +163,7 @@ public final class ProductFamiliesController extends BaseController {
         return new ApiCall.Builder<List<ProductFamilyResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families.json")
                         .queryParam(param -> param.key("date_field")
                                 .value((input.getDateField() != null) ? input.getDateField().value() : null).isRequired(false))
@@ -211,7 +211,7 @@ public final class ProductFamiliesController extends BaseController {
         return new ApiCall.Builder<ProductFamilyResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{id}.json")
                         .templateParam(param -> param.key("id").value(id).isRequired(false)
                                 .shouldEncode(true))

--- a/src/main/java/com/maxio/advancedbilling/controllers/ProductPricePointsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/ProductPricePointsController.java
@@ -78,7 +78,7 @@ public final class ProductPricePointsController extends BaseController {
         return new ApiCall.Builder<ProductPricePointResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/products/{product_id}/price_points.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -122,7 +122,7 @@ public final class ProductPricePointsController extends BaseController {
         return new ApiCall.Builder<ListProductPricePointsResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/products/{product_id}/price_points.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -178,7 +178,7 @@ public final class ProductPricePointsController extends BaseController {
         return new ApiCall.Builder<ProductPricePointResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/products/{product_id}/price_points/{price_point_id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -238,7 +238,7 @@ public final class ProductPricePointsController extends BaseController {
         return new ApiCall.Builder<ProductPricePointResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/products/{product_id}/price_points/{price_point_id}.json")
                         .queryParam(param -> param.key("currency_prices")
                                 .value(currencyPrices).isRequired(false))
@@ -286,7 +286,7 @@ public final class ProductPricePointsController extends BaseController {
         return new ApiCall.Builder<ProductPricePointResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/products/{product_id}/price_points/{price_point_id}.json")
                         .templateParam(param -> param.key("product_id").value(productId)
                                 .shouldEncode(true))
@@ -332,7 +332,7 @@ public final class ProductPricePointsController extends BaseController {
         return new ApiCall.Builder<ProductPricePointResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/products/{product_id}/price_points/{price_point_id}/unarchive.json")
                         .templateParam(param -> param.key("product_id").value(productId).isRequired(false)
                                 .shouldEncode(true))
@@ -376,7 +376,7 @@ public final class ProductPricePointsController extends BaseController {
         return new ApiCall.Builder<ProductResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/products/{product_id}/price_points/{price_point_id}/default.json")
                         .templateParam(param -> param.key("product_id").value(productId).isRequired(false)
                                 .shouldEncode(true))
@@ -419,7 +419,7 @@ public final class ProductPricePointsController extends BaseController {
         return new ApiCall.Builder<BulkCreateProductPricePointsResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/products/{product_id}/price_points/bulk.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -471,7 +471,7 @@ public final class ProductPricePointsController extends BaseController {
         return new ApiCall.Builder<CurrencyPricesResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_price_points/{product_price_point_id}/currency_prices.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -523,7 +523,7 @@ public final class ProductPricePointsController extends BaseController {
         return new ApiCall.Builder<CurrencyPricesResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_price_points/{product_price_point_id}/currency_prices.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -567,7 +567,7 @@ public final class ProductPricePointsController extends BaseController {
         return new ApiCall.Builder<ListProductPricePointsResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/products_price_points.json")
                         .queryParam(param -> param.key("direction")
                                 .value((input.getDirection() != null) ? input.getDirection().value() : null).isRequired(false))

--- a/src/main/java/com/maxio/advancedbilling/controllers/ProductsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/ProductsController.java
@@ -63,7 +63,7 @@ public final class ProductsController extends BaseController {
         return new ApiCall.Builder<ProductResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/product_families/{product_family_id}/products.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -108,7 +108,7 @@ public final class ProductsController extends BaseController {
         return new ApiCall.Builder<ProductResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/products/{product_id}.json")
                         .templateParam(param -> param.key("product_id").value(productId).isRequired(false)
                                 .shouldEncode(true))
@@ -152,7 +152,7 @@ public final class ProductsController extends BaseController {
         return new ApiCall.Builder<ProductResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/products/{product_id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -199,7 +199,7 @@ public final class ProductsController extends BaseController {
         return new ApiCall.Builder<ProductResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/products/{product_id}.json")
                         .templateParam(param -> param.key("product_id").value(productId).isRequired(false)
                                 .shouldEncode(true))
@@ -239,7 +239,7 @@ public final class ProductsController extends BaseController {
         return new ApiCall.Builder<ProductResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/products/handle/{api_handle}.json")
                         .templateParam(param -> param.key("api_handle").value(apiHandle)
                                 .shouldEncode(true))
@@ -276,7 +276,7 @@ public final class ProductsController extends BaseController {
         return new ApiCall.Builder<List<ProductResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/products.json")
                         .queryParam(param -> param.key("date_field")
                                 .value((input.getDateField() != null) ? input.getDateField().value() : null).isRequired(false))

--- a/src/main/java/com/maxio/advancedbilling/controllers/ProformaInvoicesController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/ProformaInvoicesController.java
@@ -67,7 +67,7 @@ public final class ProformaInvoicesController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}/proforma_invoices.json")
                         .templateParam(param -> param.key("uid").value(uid)
                                 .shouldEncode(true))
@@ -107,7 +107,7 @@ public final class ProformaInvoicesController extends BaseController {
         return new ApiCall.Builder<ListProformaInvoicesResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}/proforma_invoices.json")
                         .queryParam(param -> param.key("line_items")
                                 .value(input.getLineItems()).isRequired(false))
@@ -160,7 +160,7 @@ public final class ProformaInvoicesController extends BaseController {
         return new ApiCall.Builder<ProformaInvoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/proforma_invoices/{proforma_invoice_uid}.json")
                         .templateParam(param -> param.key("proforma_invoice_uid").value(proformaInvoiceUid)
                                 .shouldEncode(true))
@@ -205,7 +205,7 @@ public final class ProformaInvoicesController extends BaseController {
         return new ApiCall.Builder<ProformaInvoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/proforma_invoices.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))
@@ -248,7 +248,7 @@ public final class ProformaInvoicesController extends BaseController {
         return new ApiCall.Builder<ListProformaInvoicesResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/proforma_invoices.json")
                         .queryParam(param -> param.key("start_date")
                                 .value(input.getStartDate()).isRequired(false))
@@ -317,7 +317,7 @@ public final class ProformaInvoicesController extends BaseController {
         return new ApiCall.Builder<ProformaInvoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/proforma_invoices/{proforma_invoice_uid}/void.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -375,7 +375,7 @@ public final class ProformaInvoicesController extends BaseController {
         return new ApiCall.Builder<ProformaInvoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/proforma_invoices/preview.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))
@@ -427,7 +427,7 @@ public final class ProformaInvoicesController extends BaseController {
         return new ApiCall.Builder<ProformaInvoice, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/proforma_invoices.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -484,7 +484,7 @@ public final class ProformaInvoicesController extends BaseController {
         return new ApiCall.Builder<SignupProformaPreviewResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/proforma_invoices/preview.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))

--- a/src/main/java/com/maxio/advancedbilling/controllers/ReasonCodesController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/ReasonCodesController.java
@@ -65,7 +65,7 @@ public final class ReasonCodesController extends BaseController {
         return new ApiCall.Builder<ReasonCodeResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/reason_codes.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -108,7 +108,7 @@ public final class ReasonCodesController extends BaseController {
         return new ApiCall.Builder<List<ReasonCodeResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/reason_codes.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -152,7 +152,7 @@ public final class ReasonCodesController extends BaseController {
         return new ApiCall.Builder<ReasonCodeResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/reason_codes/{reason_code_id}.json")
                         .templateParam(param -> param.key("reason_code_id").value(reasonCodeId).isRequired(false)
                                 .shouldEncode(true))
@@ -195,7 +195,7 @@ public final class ReasonCodesController extends BaseController {
         return new ApiCall.Builder<ReasonCodeResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/reason_codes/{reason_code_id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -243,7 +243,7 @@ public final class ReasonCodesController extends BaseController {
         return new ApiCall.Builder<OkResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/reason_codes/{reason_code_id}.json")
                         .templateParam(param -> param.key("reason_code_id").value(reasonCodeId).isRequired(false)
                                 .shouldEncode(true))

--- a/src/main/java/com/maxio/advancedbilling/controllers/ReferralCodesController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/ReferralCodesController.java
@@ -57,7 +57,7 @@ public final class ReferralCodesController extends BaseController {
         return new ApiCall.Builder<ReferralValidationResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/referral_codes/validate.json")
                         .queryParam(param -> param.key("code")
                                 .value(code))

--- a/src/main/java/com/maxio/advancedbilling/controllers/SalesCommissionsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/SalesCommissionsController.java
@@ -65,7 +65,7 @@ public final class SalesCommissionsController extends BaseController {
         return new ApiCall.Builder<List<SaleRepSettings>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/sellers/{seller_id}/sales_commission_settings.json")
                         .queryParam(param -> param.key("live_mode")
                                 .value(input.getLiveMode()).isRequired(false))
@@ -121,7 +121,7 @@ public final class SalesCommissionsController extends BaseController {
         return new ApiCall.Builder<List<ListSaleRepItem>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/sellers/{seller_id}/sales_reps.json")
                         .queryParam(param -> param.key("live_mode")
                                 .value(input.getLiveMode()).isRequired(false))
@@ -202,7 +202,7 @@ public final class SalesCommissionsController extends BaseController {
         return new ApiCall.Builder<SaleRep, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/sellers/{seller_id}/sales_reps/{sales_rep_id}.json")
                         .queryParam(param -> param.key("live_mode")
                                 .value(liveMode).isRequired(false))

--- a/src/main/java/com/maxio/advancedbilling/controllers/SitesController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/SitesController.java
@@ -58,7 +58,7 @@ public final class SitesController extends BaseController {
         return new ApiCall.Builder<SiteResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/site.json")
                         .headerParam(param -> param.key("accept").value("application/json"))
                         .withAuth(auth -> auth
@@ -99,7 +99,7 @@ public final class SitesController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/sites/clear_data.json")
                         .queryParam(param -> param.key("cleanup_scope")
                                 .value((cleanupScope != null) ? cleanupScope.value() : "all").isRequired(false))
@@ -133,7 +133,7 @@ public final class SitesController extends BaseController {
         return new ApiCall.Builder<ListPublicKeysResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/chargify_js_keys.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))

--- a/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionComponentsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionComponentsController.java
@@ -80,7 +80,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<SubscriptionComponentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/components/{component_id}.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))
@@ -124,7 +124,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<List<SubscriptionComponentResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/components.json")
                         .queryParam(param -> param.key("date_field")
                                 .value((input.getDateField() != null) ? input.getDateField().value() : null).isRequired(false))
@@ -192,7 +192,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<BulkComponentsPricePointAssignment, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/price_points.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -238,7 +238,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/price_points/reset.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))
@@ -322,7 +322,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<AllocationResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/components/{component_id}/allocations.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -386,7 +386,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<List<AllocationResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/components/{component_id}/allocations.json")
                         .queryParam(param -> param.key("page")
                                 .value((page != null) ? page : 1).isRequired(false))
@@ -442,7 +442,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<List<AllocationResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/allocations.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -501,7 +501,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<AllocationPreviewResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/allocations/preview.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -563,7 +563,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/components/{component_id}/allocations/{allocation_id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -630,7 +630,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/components/{component_id}/allocations/{allocation_id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -718,7 +718,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<UsageResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/components/{component_id}/usages.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -772,7 +772,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<List<UsageResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/components/{component_id}/usages.json")
                         .queryParam(param -> param.key("since_id")
                                 .value(input.getSinceId()).isRequired(false))
@@ -837,7 +837,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/event_based_billing/subscriptions/{subscription_id}/components/{component_id}/activate.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -881,7 +881,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/event_based_billing/subscriptions/{subscription_id}/components/{component_id}/deactivate.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))
@@ -908,7 +908,6 @@ public final class SubscriptionComponentsController extends BaseController {
      * the standard Chargify API endpoints in that the URL subdomain will be `events` and your site
      * subdomain will be included in the URL path. For example:* ```
      * https://events.chargify.com/my-site-subdomain/events/my-stream-api-handle ```.
-     * @param  subdomain  Required parameter: Your site's subdomain
      * @param  apiHandle  Required parameter: Identifies the Stream for which the event should be
      *         published.
      * @param  storeUid  Optional parameter: If you've attached your own Keen project as an Advanced
@@ -918,32 +917,28 @@ public final class SubscriptionComponentsController extends BaseController {
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
     public void recordEvent(
-            final String subdomain,
             final String apiHandle,
             final String storeUid,
             final EBBEvent body) throws ApiException, IOException {
-        prepareRecordEventRequest(subdomain, apiHandle, storeUid, body).execute();
+        prepareRecordEventRequest(apiHandle, storeUid, body).execute();
     }
 
     /**
      * Builds the ApiCall object for recordEvent.
      */
     private ApiCall<Void, ApiException> prepareRecordEventRequest(
-            final String subdomain,
             final String apiHandle,
             final String storeUid,
             final EBBEvent body) throws JsonProcessingException, IOException {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
-                        .path("/{subdomain}/events/{api_handle}.json")
+                        .server(Server.EBB.value())
+                        .path("/events/{api_handle}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
                         .queryParam(param -> param.key("store_uid")
                                 .value(storeUid).isRequired(false))
-                        .templateParam(param -> param.key("subdomain").value(subdomain)
-                                .shouldEncode(true))
                         .templateParam(param -> param.key("api_handle").value(apiHandle)
                                 .shouldEncode(true))
                         .headerParam(param -> param.key("Content-Type")
@@ -963,7 +958,6 @@ public final class SubscriptionComponentsController extends BaseController {
      * standard Chargify API endpoints in that the subdomain will be `events` and your site
      * subdomain will be included in the URL path.* A maximum of 1000 events can be published in a
      * single request. A 422 will be returned if this limit is exceeded.
-     * @param  subdomain  Required parameter: Your site's subdomain
      * @param  apiHandle  Required parameter: Identifies the Stream for which the events should be
      *         published.
      * @param  storeUid  Optional parameter: If you've attached your own Keen project as an Advanced
@@ -973,32 +967,28 @@ public final class SubscriptionComponentsController extends BaseController {
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
     public void bulkRecordEvents(
-            final String subdomain,
             final String apiHandle,
             final String storeUid,
             final List<EBBEvent> body) throws ApiException, IOException {
-        prepareBulkRecordEventsRequest(subdomain, apiHandle, storeUid, body).execute();
+        prepareBulkRecordEventsRequest(apiHandle, storeUid, body).execute();
     }
 
     /**
      * Builds the ApiCall object for bulkRecordEvents.
      */
     private ApiCall<Void, ApiException> prepareBulkRecordEventsRequest(
-            final String subdomain,
             final String apiHandle,
             final String storeUid,
             final List<EBBEvent> body) throws JsonProcessingException, IOException {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
-                        .path("/{subdomain}/events/{api_handle}/bulk.json")
+                        .server(Server.EBB.value())
+                        .path("/events/{api_handle}/bulk.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
                         .queryParam(param -> param.key("store_uid")
                                 .value(storeUid).isRequired(false))
-                        .templateParam(param -> param.key("subdomain").value(subdomain)
-                                .shouldEncode(true))
                         .templateParam(param -> param.key("api_handle").value(apiHandle)
                                 .shouldEncode(true))
                         .headerParam(param -> param.key("Content-Type")
@@ -1033,7 +1023,7 @@ public final class SubscriptionComponentsController extends BaseController {
         return new ApiCall.Builder<ListSubscriptionComponentsResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions_components.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))

--- a/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionGroupInvoiceAccountController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionGroupInvoiceAccountController.java
@@ -64,7 +64,7 @@ public final class SubscriptionGroupInvoiceAccountController extends BaseControl
         return new ApiCall.Builder<SubscriptionGroupPrepaymentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}/prepayments.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -108,7 +108,7 @@ public final class SubscriptionGroupInvoiceAccountController extends BaseControl
         return new ApiCall.Builder<ListSubscriptionGroupPrepaymentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}/prepayments.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -159,7 +159,7 @@ public final class SubscriptionGroupInvoiceAccountController extends BaseControl
         return new ApiCall.Builder<ServiceCreditResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}/service_credits.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -207,7 +207,7 @@ public final class SubscriptionGroupInvoiceAccountController extends BaseControl
         return new ApiCall.Builder<ServiceCredit, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}/service_credit_deductions.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))

--- a/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionGroupStatusController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionGroupStatusController.java
@@ -61,7 +61,7 @@ public final class SubscriptionGroupStatusController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}/cancel.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -104,7 +104,7 @@ public final class SubscriptionGroupStatusController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}/delayed_cancel.json")
                         .templateParam(param -> param.key("uid").value(uid)
                                 .shouldEncode(true))
@@ -142,7 +142,7 @@ public final class SubscriptionGroupStatusController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}/delayed_cancel.json")
                         .templateParam(param -> param.key("uid").value(uid)
                                 .shouldEncode(true))
@@ -205,7 +205,7 @@ public final class SubscriptionGroupStatusController extends BaseController {
         return new ApiCall.Builder<ReactivateSubscriptionGroupResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}/reactivate.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))

--- a/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionGroupsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionGroupsController.java
@@ -74,7 +74,7 @@ public final class SubscriptionGroupsController extends BaseController {
         return new ApiCall.Builder<SubscriptionGroupSignupResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/signup.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -116,7 +116,7 @@ public final class SubscriptionGroupsController extends BaseController {
         return new ApiCall.Builder<SubscriptionGroupResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -162,7 +162,7 @@ public final class SubscriptionGroupsController extends BaseController {
         return new ApiCall.Builder<ListSubscriptionGroupsResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -210,7 +210,7 @@ public final class SubscriptionGroupsController extends BaseController {
         return new ApiCall.Builder<FullSubscriptionGroupResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}.json")
                         .queryParam(param -> param.key("include")
                                 .value(SubscriptionGroupInclude.toValue(include)).isRequired(false))
@@ -255,7 +255,7 @@ public final class SubscriptionGroupsController extends BaseController {
         return new ApiCall.Builder<SubscriptionGroupResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -299,7 +299,7 @@ public final class SubscriptionGroupsController extends BaseController {
         return new ApiCall.Builder<DeleteSubscriptionGroupResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/{uid}.json")
                         .templateParam(param -> param.key("uid").value(uid)
                                 .shouldEncode(true))
@@ -341,7 +341,7 @@ public final class SubscriptionGroupsController extends BaseController {
         return new ApiCall.Builder<FullSubscriptionGroupResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscription_groups/lookup.json")
                         .queryParam(param -> param.key("subscription_id")
                                 .value(subscriptionId))
@@ -405,7 +405,7 @@ public final class SubscriptionGroupsController extends BaseController {
         return new ApiCall.Builder<SubscriptionGroupResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/group.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -449,7 +449,7 @@ public final class SubscriptionGroupsController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/group.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))

--- a/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionInvoiceAccountController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionInvoiceAccountController.java
@@ -62,7 +62,7 @@ public final class SubscriptionInvoiceAccountController extends BaseController {
         return new ApiCall.Builder<AccountBalances, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/account_balances.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))
@@ -106,7 +106,7 @@ public final class SubscriptionInvoiceAccountController extends BaseController {
         return new ApiCall.Builder<CreatePrepaymentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/prepayments.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -150,7 +150,7 @@ public final class SubscriptionInvoiceAccountController extends BaseController {
         return new ApiCall.Builder<PrepaymentsResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/prepayments.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -200,7 +200,7 @@ public final class SubscriptionInvoiceAccountController extends BaseController {
         return new ApiCall.Builder<ServiceCredit, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/service_credits.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -247,7 +247,7 @@ public final class SubscriptionInvoiceAccountController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/service_credit_deductions.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -297,7 +297,7 @@ public final class SubscriptionInvoiceAccountController extends BaseController {
         return new ApiCall.Builder<PrepaymentResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/prepayments/{prepayment_id}/refunds.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))

--- a/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionNotesController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionNotesController.java
@@ -60,7 +60,7 @@ public final class SubscriptionNotesController extends BaseController {
         return new ApiCall.Builder<SubscriptionNoteResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/notes.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -102,7 +102,7 @@ public final class SubscriptionNotesController extends BaseController {
         return new ApiCall.Builder<List<SubscriptionNoteResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/notes.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -148,7 +148,7 @@ public final class SubscriptionNotesController extends BaseController {
         return new ApiCall.Builder<SubscriptionNoteResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/notes/{note_id}.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))
@@ -193,7 +193,7 @@ public final class SubscriptionNotesController extends BaseController {
         return new ApiCall.Builder<SubscriptionNoteResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/notes/{note_id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -238,7 +238,7 @@ public final class SubscriptionNotesController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/notes/{note_id}.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))

--- a/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionProductsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionProductsController.java
@@ -111,7 +111,7 @@ public final class SubscriptionProductsController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/migrations.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -162,7 +162,7 @@ public final class SubscriptionProductsController extends BaseController {
         return new ApiCall.Builder<SubscriptionMigrationPreviewResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/migrations/preview.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))

--- a/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionStatusController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionStatusController.java
@@ -62,7 +62,7 @@ public final class SubscriptionStatusController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/retry.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))
@@ -106,7 +106,7 @@ public final class SubscriptionStatusController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -160,7 +160,7 @@ public final class SubscriptionStatusController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/resume.json")
                         .queryParam(param -> param.key("calendar_billing['resumption_charge']")
                                 .value((calendarBillingResumptionCharge != null) ? calendarBillingResumptionCharge.value() : "prorated").isRequired(false))
@@ -206,7 +206,7 @@ public final class SubscriptionStatusController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/hold.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -257,7 +257,7 @@ public final class SubscriptionStatusController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/hold.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -373,7 +373,7 @@ public final class SubscriptionStatusController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/reactivate.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -424,7 +424,7 @@ public final class SubscriptionStatusController extends BaseController {
         return new ApiCall.Builder<DelayedCancellationResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/delayed_cancel.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -474,7 +474,7 @@ public final class SubscriptionStatusController extends BaseController {
         return new ApiCall.Builder<DelayedCancellationResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/delayed_cancel.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))
@@ -515,7 +515,7 @@ public final class SubscriptionStatusController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/cancel_dunning.json")
                         .templateParam(param -> param.key("subscription_id").value(subscriptionId).isRequired(false)
                                 .shouldEncode(true))
@@ -578,7 +578,7 @@ public final class SubscriptionStatusController extends BaseController {
         return new ApiCall.Builder<RenewalPreviewResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/renewals/preview.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))

--- a/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionsController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/SubscriptionsController.java
@@ -449,7 +449,7 @@ public final class SubscriptionsController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -496,7 +496,7 @@ public final class SubscriptionsController extends BaseController {
         return new ApiCall.Builder<List<SubscriptionResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions.json")
                         .queryParam(param -> param.key("page")
                                 .value(input.getPage()).isRequired(false))
@@ -604,7 +604,7 @@ public final class SubscriptionsController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -654,7 +654,7 @@ public final class SubscriptionsController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}.json")
                         .queryParam(param -> param.key("include")
                                 .value(SubscriptionInclude.toValue(include)).isRequired(false))
@@ -716,7 +716,7 @@ public final class SubscriptionsController extends BaseController {
         return new ApiCall.Builder<Void, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/override.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -757,7 +757,7 @@ public final class SubscriptionsController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/lookup.json")
                         .queryParam(param -> param.key("reference")
                                 .value(reference).isRequired(false))
@@ -810,7 +810,7 @@ public final class SubscriptionsController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/purge.json")
                         .queryParam(param -> param.key("ack")
                                 .value(ack).isRequired(false))
@@ -857,7 +857,7 @@ public final class SubscriptionsController extends BaseController {
         return new ApiCall.Builder<PrepaidConfigurationResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/prepaid_configurations.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -922,7 +922,7 @@ public final class SubscriptionsController extends BaseController {
         return new ApiCall.Builder<SubscriptionPreviewResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/preview.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -977,7 +977,7 @@ public final class SubscriptionsController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/add_coupon.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -1028,7 +1028,7 @@ public final class SubscriptionsController extends BaseController {
         return new ApiCall.Builder<String, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/remove_coupon.json")
                         .queryParam(param -> param.key("coupon_code")
                                 .value(couponCode).isRequired(false))
@@ -1097,7 +1097,7 @@ public final class SubscriptionsController extends BaseController {
         return new ApiCall.Builder<SubscriptionResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/subscriptions/{subscription_id}/activate.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))

--- a/src/main/java/com/maxio/advancedbilling/controllers/WebhooksController.java
+++ b/src/main/java/com/maxio/advancedbilling/controllers/WebhooksController.java
@@ -76,7 +76,7 @@ public final class WebhooksController extends BaseController {
         return new ApiCall.Builder<List<WebhookResponse>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/webhooks.json")
                         .queryParam(param -> param.key("status")
                                 .value((input.getStatus() != null) ? input.getStatus().value() : null).isRequired(false))
@@ -126,7 +126,7 @@ public final class WebhooksController extends BaseController {
         return new ApiCall.Builder<EnableWebhooksResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/webhooks/settings.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -167,7 +167,7 @@ public final class WebhooksController extends BaseController {
         return new ApiCall.Builder<ReplayWebhooksResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/webhooks/replay.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -208,7 +208,7 @@ public final class WebhooksController extends BaseController {
         return new ApiCall.Builder<EndpointResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/endpoints.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))
@@ -247,7 +247,7 @@ public final class WebhooksController extends BaseController {
         return new ApiCall.Builder<List<Endpoint>, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/endpoints.json")
                         .headerParam(param -> param.key("accept").value("application/json"))
                         .withAuth(auth -> auth
@@ -294,7 +294,7 @@ public final class WebhooksController extends BaseController {
         return new ApiCall.Builder<EndpointResponse, ApiException>()
                 .globalConfig(getGlobalConfiguration())
                 .requestBuilder(requestBuilder -> requestBuilder
-                        .server(Server.ENUM_DEFAULT.value())
+                        .server(Server.PRODUCTION.value())
                         .path("/endpoints/{endpoint_id}.json")
                         .bodyParam(param -> param.value(body).isRequired(false))
                         .bodySerializer(() ->  ApiHelper.serialize(body))

--- a/src/main/java/com/maxio/advancedbilling/models/InvoiceStatus.java
+++ b/src/main/java/com/maxio/advancedbilling/models/InvoiceStatus.java
@@ -27,7 +27,9 @@ public enum InvoiceStatus {
 
     VOIDED,
 
-    CANCELED;
+    CANCELED,
+
+    PROCESSING;
 
 
     private static TreeMap<String, InvoiceStatus> valueMap = new TreeMap<>();
@@ -40,6 +42,7 @@ public enum InvoiceStatus {
         PENDING.value = "pending";
         VOIDED.value = "voided";
         CANCELED.value = "canceled";
+        PROCESSING.value = "processing";
 
         valueMap.put("draft", DRAFT);
         valueMap.put("open", OPEN);
@@ -47,6 +50,7 @@ public enum InvoiceStatus {
         valueMap.put("pending", PENDING);
         valueMap.put("voided", VOIDED);
         valueMap.put("canceled", CANCELED);
+        valueMap.put("processing", PROCESSING);
     }
 
     /**


### PR DESCRIPTION
- added `processing` Invoice Status
- removed `Environment.ENVIRONMENT2` `AdvancedBillingClient` environment option
- fixed `recordEvent` and `bulkRecordEvents`. Now they work with default environment, with subdomain specified during client initialization. They no longer need subdomain provided to the method execution 