### PR TITLE
Fix error message in CouponsControllerCreateCouponTest for clarity

### DIFF
--- a/tests/src/test/java/com/maxio/advancedbilling/controllers/coupons/CouponsControllerCreateCouponTest.java
+++ b/tests/src/test/java/com/maxio/advancedbilling/controllers/coupons/CouponsControllerCreateCouponTest.java
@@ -152,7 +152,7 @@ public class CouponsControllerCreateCouponTest extends CouponsControllerTestBase
                         )
                 ))
                 .isUnprocessableEntity()
-                .hasErrors("Either a Discount Percentage or Amount must be specified, but not both",
+                .hasErrors("Either a Discount Percentage or an Amount must be specified, but not both.",
                         "Cannot create prices for a percentage-based coupon.");
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update expected error string in `CouponsControllerCreateCouponTest` for the case when both percentage and amount are set, aligning wording and punctuation with API response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 563c5417f2abe25ff444fea52b0c1fd9d647ccd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->